### PR TITLE
add tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import 'bulma/css/bulma.css';
 import '@fortawesome/fontawesome-free/css/all.css';
 import './App.scss';
+import { Tabs } from './components/Tabs/Tabs';
 
 export const tabs = [
   { id: 'tab-1', title: 'Tab 1', content: 'Some text 1' },
@@ -9,32 +10,26 @@ export const tabs = [
   { id: 'tab-3', title: 'Tab 3', content: 'Some text 3' },
 ];
 
-export const App = () => (
-  <div className="section">
-    <h1 className="title">
-      Selected tab is Tab 1
-    </h1>
+export const App = () => {
+  const [selectedTab, setSelectedTab] = useState(tabs[0]);
 
-    <div data-cy="TabsComponent">
-      <div className="tabs is-boxed">
-        <ul>
-          <li className="is-active" data-cy="Tab">
-            <a href="#tab-1" data-cy="TabLink">Tab 1</a>
-          </li>
+  const handleTabSelected = (tab) => {
+    setSelectedTab(tab);
+  };
 
-          <li data-cy="Tab">
-            <a href="#tab-2" data-cy="TabLink">Tab 2</a>
-          </li>
+  return (
+    <div className="section">
+      <h1 className="title">
+        Selected tab is
+        {' '}
+        {selectedTab.title}
+      </h1>
 
-          <li data-cy="Tab">
-            <a href="#tab-3" data-cy="TabLink">Tab 3</a>
-          </li>
-        </ul>
-      </div>
-
-      <div className="block" data-cy="TabContent">
-        Some text 1
-      </div>
+      <Tabs
+        tabs={tabs}
+        selectedTab={selectedTab}
+        onTabSelected={handleTabSelected}
+      />
     </div>
-  </div>
-);
+  );
+};

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -1,1 +1,33 @@
-export const Tabs = () => {};
+import React from 'react';
+
+export const Tabs = ({ tabs, selectedTab, onTabSelected }) => (
+  <div data-cy="TabsComponent">
+    <div className="tabs is-boxed">
+      <ul>
+        {tabs.map(tab => (
+          <li
+            key={tab.id}
+            className={tab === selectedTab ? 'is-active' : ''}
+            data-cy="Tab"
+          >
+            <a
+              href={`#${tab.id}`}
+              data-cy="TabLink"
+              onClick={() => {
+                if (tab !== selectedTab) {
+                  onTabSelected(tab);
+                }
+              }}
+            >
+              {tab.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+
+    <div className="block" data-cy="TabContent">
+      {selectedTab.content}
+    </div>
+  </div>
+);


### PR DESCRIPTION
[DEMO LINK](https://MaxKalalashnyk02.github.io/react_tabs-js/)

1. Save the `selectedTab` in the `App` (the first `tab` is selected by default);
1. Implement the `Tabs` component accepting `tabs` as a prop and displaying a link per each `tab` and the content of the selected tab.
1. Each link should have a href with a `#tab-id` (see the markup).
1. Pass the `selectedTab` as a prop to the `Tabs`, the specified tab should be selected if possible
  (otherwise, the first tab is selected).
1. The `Tabs` should show the content of the selected tab (add an attribute `data-cy="tab-content"` for testing).
1. The selected tab (`li`) should have an `is-active` class.
1. Pass the `onTabSelected` callback to the `Tabs`, it should be called whenever the user selects another tab.
   (Don't call the callback if the tab was not changed)
1. The callback should receive the data of the selected tab (an object from the array)
1. The `App` title (`h1`) should show a text saying `Selected tab is Tab 1` (show the title of the selected tab).
1. When the user selects another tab the `h1` should be updated accordingly.
1. The `Tabs` component should be stateless (don't have an internal state, only props).